### PR TITLE
Added function to TransactionHelper to get balance without conversion to ether

### DIFF
--- a/oneinch_py/main.py
+++ b/oneinch_py/main.py
@@ -309,6 +309,11 @@ class TransactionHelper:
         else:
             return balance_in_wei / 10 ** decimal
 
+    def get_ERC20_balance_in_wei(self, contract_address):
+        contract = self.w3.eth.contract(address=self.w3.to_checksum_address(contract_address), abi=self.abi)
+        balance_in_wei = contract.functions.balanceOf(self.public_key).call()
+        return balance_in_wei
+        
     def decode_abi(self, transaction):
         contract = self.w3.eth.contract(address=self.w3.to_checksum_address('0x1111111254EEB25477B68fb85Ed929f73A960582'), abi=self.abi_aggregator)
         data = transaction['tx']['data']

--- a/oneinch_py/main.py
+++ b/oneinch_py/main.py
@@ -166,7 +166,12 @@ class OneInchSwap:
                 decimal = self.tokens[from_token_symbol]['decimals']
         else:
             pass
-        amount_in_wei = Decimal(amount * 10 ** decimal)
+                        
+        if(decimal == 0):
+            amount_in_wei = int(amount)
+        else:
+            amount_in_wei = int(amount * 10 ** decimal)
+        
         url = f'{self.base_url}/{self.version}/{self.chain_id}/swap'
         url = url + f'?fromTokenAddress={from_address}&toTokenAddress={to_address}&amount={amount_in_wei}'
         url = url + f'&fromAddress={send_address}&slippage={slippage}'


### PR DESCRIPTION
Added function ```get_ERC20_balance_in_wei(self, contract_address)``` to ```TransactionHelper```  to get balance without conversion to ether, for those who want to swap their whole balance. Floating point errors can happen when using the ```TransactionHelper``` to get balance then convert to wei again to swap the amounts. Previously the process would be the following using ```TransactionHelper``` : ```int(wei) -> float(ether) -> int(wei)```, now it is: ```int(wei) -> int(wei)```. This same thing can be done with putting decimals = 0 in the ```get_ERC20_balance(...)``` function, but this is neater.