### PR TITLE
Authentication and new API URLs; Resolves #19

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-# THe recent changes to the API have broken the wrapper. I do not have the capacity at the moment to update it. Pull requests welcome.
 
 # 1inch.py
 
@@ -30,9 +29,10 @@ rpc_url = "yourRPCURL.com"
 binance_rpc = "adifferentRPCurl.com"
 public_key = "yourWalletAddress"
 private_key = "yourPrivateKey" #remember to protect your private key. Using environmental variables is recommended. 
+api_key = "" # 1 Inch API key
 
-exchange = OneInchSwap(public_key)
-bsc_exchange = OneInchSwap(public_key, chain='binance')
+exchange = OneInchSwap(api_key, public_key)
+bsc_exchange = OneInchSwap(api_key, public_key, chain='binance')
 helper = TransactionHelper(rpc_url, public_key, private_key)
 bsc_helper = TransactionHelper(binance_rpc, public_key, private_key, chain='binance')
 oracle = OneInchOracle(rpc_url, chain='ethereum')

--- a/oneinch_py/main.py
+++ b/oneinch_py/main.py
@@ -304,12 +304,17 @@ class TransactionHelper:
         return tx
 
     def sign_tx(self, tx):
+        if tx == None:
+            return None
         signed_tx = self.w3.eth.account.sign_transaction(tx, self.private_key)
         return signed_tx
 
     def broadcast_tx(self, signed_tx, timeout=360):
         api_base_url = 'https://api.1inch.dev/tx-gateway/v1.1/'
         api_headers = {"accept": "application/json", "Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"}
+
+        if signed_tx == None:
+            return None
         if self.broadcast_1inch is True:
             tx_json = signed_tx.rawTransaction
             tx_json = {"rawTransaction": tx_json.hex()}

--- a/oneinch_py/main.py
+++ b/oneinch_py/main.py
@@ -11,11 +11,11 @@ class UnknownToken(Exception):
 
 
 class OneInchSwap:
-    base_url = 'https://api.1inch.io'
+    base_url = 'https://api.1inch.dev/swap'
+    api_key = ''
 
     version = {
-        "v4.0": "v4.0",
-        "v5.0": "v5.0"
+        "v5.2": "v5.2"
     }
 
     chains = {
@@ -29,30 +29,38 @@ class OneInchSwap:
         "fantom": "250"
     }
 
-    def __init__(self, address, chain='ethereum', version='v5.0'):
+    def __init__(self, api_key, address, chain='ethereum', version='v5.2'):
         self.presets = None
         self.tokens = {}
         self.tokens_by_address = {}
         self.protocols = []
         self.address = address
+        self.api_key = api_key
         self.version = version
         self.chain_id = self.chains[chain]
         self.chain = chain
         self.tokens = self.get_tokens()
         self.spender = self.get_spender()
 
-    @staticmethod
-    def _get(url, params=None, headers=None):
+   
+    def _get(self, url, params=None, headers=None):
         """ Implements a get request """
         try:
+            auth = ("Authorization", f"Bearer {self.api_key}")
+            if (headers == None):
+                headers = {"accept": "application/json", "Authorization": f"Bearer {self.api_key}"}
+            else:
+                headers["accept"] = "application/json"
+                headers["Authorization"] = f"Bearer {self.api_key}"
             response = requests.get(url, params=params, headers=headers)
             response.raise_for_status()
             payload = response.json()
         except requests.exceptions.ConnectionError as e:
             print("ConnectionError when doing a GET request from {}".format(url))
             payload = None
-        except requests.exceptions.HTTPError:
+        except requests.exceptions.HTTPError as e:
             print("HTTPError {}".format(url))
+            print(e.response)
             payload = None
         return payload
 

--- a/oneinch_py/main.py
+++ b/oneinch_py/main.py
@@ -46,7 +46,7 @@ class OneInchSwap:
     def _get(self, url, params=None, headers=None):
         """ Implements a get request """
         try:
-            if (headers == None):
+            if headers == None:
                 headers = {"accept": "application/json", "Authorization": f"Bearer {self.api_key}"}
             else:
                 headers["accept"] = "application/json"
@@ -224,6 +224,7 @@ class OneInchSwap:
 
 
 class TransactionHelper:
+    # 1Inch gas oracle doesn't seem to exist any longer
     gas_oracle = "https://gas-price-api.1inch.io/v1.3/"
 
     chains = {
@@ -243,10 +244,15 @@ class TransactionHelper:
     abi = json.loads(pkg_resources.read_text(__package__, 'erc20.json'))['result']
     abi_aggregator = json.loads(pkg_resources.read_text(__package__, 'aggregatorv5.json'))['result']
 
-    @staticmethod
-    def _get(url, params=None, headers=None):
+    def _get(self, url, params=None, headers=None):
         """ Implements a get request """
         try:
+            if headers == None:
+                headers = {"accept": "application/json", "Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"}
+            else:
+                headers["accept"] = "application/json"
+                headers["Authorization"] = f"Bearer {self.api_key}"
+                headers["Content-Type"] = "application/json"
             response = requests.get(url, params=params, headers=headers)
             response.raise_for_status()
             payload = response.json()
@@ -258,12 +264,13 @@ class TransactionHelper:
             payload = None
         return payload
 
-    def __init__(self, rpc_url, public_key, private_key, chain='ethereum', broadcast_1inch=False):
+    def __init__(self,  api_key, rpc_url, public_key, private_key, chain='ethereum', broadcast_1inch=False):
         self.w3 = Web3(Web3.HTTPProvider(rpc_url))
         if chain == 'polygon' or chain == 'avalanche':
             self.w3.middleware_onion.inject(geth_poa_middleware, layer=0)
         else:
             pass
+        self.api_key =  api_key
         self.public_key = public_key
         self.private_key = private_key
         self.chain = chain
@@ -272,6 +279,8 @@ class TransactionHelper:
 
     def build_tx(self, raw_tx, speed='high'):
         nonce = self.w3.eth.get_transaction_count(self.public_key)
+        if raw_tx == None:
+            return None
         if 'tx' in raw_tx:
             tx = raw_tx['tx']
         else:
@@ -286,7 +295,7 @@ class TransactionHelper:
         tx['value'] = int(tx['value'])
         tx['gas'] = int(tx['gas'] * 1.25)
         if self.chain == 'ethereum' or self.chain == 'polygon' or self.chain == 'avalanche' or self.chain == 'gnosis' or self.chain == 'klaytn':
-            gas = self._get(self.gas_oracle+self.chain_id)
+            gas = self._get(self.gas_oracle + self.chain_id)
             tx['maxPriorityFeePerGas'] = int(gas[speed]['maxPriorityFeePerGas'])
             tx['maxFeePerGas'] = int(gas[speed]['maxFeePerGas'])
             tx.pop('gasPrice')
@@ -299,10 +308,12 @@ class TransactionHelper:
         return signed_tx
 
     def broadcast_tx(self, signed_tx, timeout=360):
+        api_base_url = 'https://api.1inch.dev/tx-gateway/v1.1/'
+        api_headers = {"accept": "application/json", "Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"}
         if self.broadcast_1inch is True:
             tx_json = signed_tx.rawTransaction
             tx_json = {"rawTransaction": tx_json.hex()}
-            payload = requests.post('https://tx-gateway.1inch.io/v1.1/' + self.chain_id + '/broadcast', data=self.w3.toJSON(tx_json), headers={"accept": "application/json, text/plain, */*", "content-type": "application/json"})
+            payload = requests.post(api_base_url + self.chain_id + "/broadcast", data=self.w3.toJSON(tx_json), headers=api_headers)
             tx_hash = json.loads(payload.text)
             tx_hash = tx_hash['transactionHash']
             receipt = self.w3.eth.wait_for_transaction_receipt(tx_hash, timeout=timeout)

--- a/oneinch_py/main.py
+++ b/oneinch_py/main.py
@@ -46,7 +46,6 @@ class OneInchSwap:
     def _get(self, url, params=None, headers=None):
         """ Implements a get request """
         try:
-            auth = ("Authorization", f"Bearer {self.api_key}")
             if (headers == None):
                 headers = {"accept": "application/json", "Authorization": f"Bearer {self.api_key}"}
             else:
@@ -56,11 +55,12 @@ class OneInchSwap:
             response.raise_for_status()
             payload = response.json()
         except requests.exceptions.ConnectionError as e:
-            print("ConnectionError when doing a GET request from {}".format(url))
+            print(f"ConnectionError with code {e.response.status_code} when doing a GET request from {format(url)}")
+            print(f"Full error content {e.response._content}")
             payload = None
         except requests.exceptions.HTTPError as e:
-            print("HTTPError {}".format(url))
-            print(e.response)
+            print(f"HTTPError with code {e.response.status_code} for a request {format(url)}")
+            print(f"Full error content {e.response._content}")
             payload = None
         return payload
 


### PR DESCRIPTION
@RichardAtCT, I was able to make some updates to the code. I have done the following:
* Updated the API URLs in both OracleSwap and TransactionHelper classes
* Added authentication options to both OracleSwap and TransactionHelper classes
* Updated readme.md to include the added `api_key` parameter
* Added a bit more error details in OracleSwap
* Added a bit better error checking for None in TransactionHelper

I have done some testing, but not too extensively, didn't run any live transactions. However, the API's themselves didn't seem to have changed only the end points and authentication, so I relied on that. 

Looks like the gas oracle API is no longer there, I just added a comment but left the code is for a future update.

If some of the code is not up to par, don't hesitate to let me know. I hope these updates can be incorporated and be helpful to all.