### PR TITLE
Allow methods to accept token symbols as arguments, fixes #21

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ exchange.get_swap(from_token_symbol='ETH', to_token_symbol='USDT', amount=1, sli
 ## Contributing
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
 
+Thanks to @Makbeta for all of their work in migrating the wrapper to the new 1inch api system.
+
 
 ## License
 [MIT](https://choosealicense.com/licenses/mit/)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-# THe recent changes to the API have broken the wrapper. I do not have the capacity at the moment to update it. Pull requests welcome.
 
 # 1inch.py
 
@@ -30,9 +29,10 @@ rpc_url = "yourRPCURL.com"
 binance_rpc = "adifferentRPCurl.com"
 public_key = "yourWalletAddress"
 private_key = "yourPrivateKey" #remember to protect your private key. Using environmental variables is recommended. 
+api_key = "" # 1 Inch API key
 
-exchange = OneInchSwap(public_key)
-bsc_exchange = OneInchSwap(public_key, chain='binance')
+exchange = OneInchSwap(api_key, public_key)
+bsc_exchange = OneInchSwap(api_key, public_key, chain='binance')
 helper = TransactionHelper(rpc_url, public_key, private_key)
 bsc_helper = TransactionHelper(binance_rpc, public_key, private_key, chain='binance')
 oracle = OneInchOracle(rpc_url, chain='ethereum')

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ api_key = "" # 1 Inch API key
 
 exchange = OneInchSwap(api_key, public_key)
 bsc_exchange = OneInchSwap(api_key, public_key, chain='binance')
-helper = TransactionHelper(rpc_url, public_key, private_key)
-bsc_helper = TransactionHelper(binance_rpc, public_key, private_key, chain='binance')
+helper = TransactionHelper(api_key, rpc_url, public_key, private_key)
+bsc_helper = TransactionHelper(api_key, binance_rpc, public_key, private_key, chain='binance')
 oracle = OneInchOracle(rpc_url, chain='ethereum')
 
 
@@ -48,6 +48,10 @@ result = exchange.get_swap("USDT", "ETH", 10, 0.5) # get the swap transaction
 result = helper.build_tx(result) # prepare the transaction for signing, gas price defaults to fast.
 result = helper.sign_tx(result) # sign the transaction using your private key
 result = helper.broadcast_tx(result) #broadcast the transaction to the network and wait for the receipt. 
+
+## If you already have token addresses you can pass those in instead of token names to all OneInchSwap functions that require a token argument
+result = exchange.get_swap("0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9", "0x43dfc4159d86f3a37a5a4b3d4580b888ad7d4ddd", 10, 0.5) 
+
 
 #USDT to ETH price on the Oracle. Note that you need to indicate the token decimal if it is anything other than 18.
 oracle.get_rate_to_ETH("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", src_token_decimal=6)

--- a/oneinch_py/main.py
+++ b/oneinch_py/main.py
@@ -237,7 +237,8 @@ class TransactionHelper:
         "avalanche": "43114",
         "fantom": "250",
         "klaytn": "8217",
-        "aurora": "1313161554"
+        "aurora": "1313161554",
+        "zksync": "324"
     }
 
 

--- a/oneinch_py/main.py
+++ b/oneinch_py/main.py
@@ -304,12 +304,17 @@ class TransactionHelper:
         return tx
 
     def sign_tx(self, tx):
+        if tx == None:
+            return None
         signed_tx = self.w3.eth.account.sign_transaction(tx, self.private_key)
         return signed_tx
 
     def broadcast_tx(self, signed_tx, timeout=360):
         api_base_url = 'https://api.1inch.dev/tx-gateway/v1.1/'
         api_headers = {"accept": "application/json", "Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"}
+
+        if signed_tx == None:
+            return None
         if self.broadcast_1inch is True:
             tx_json = signed_tx.rawTransaction
             tx_json = {"rawTransaction": tx_json.hex()}

--- a/oneinch_py/main.py
+++ b/oneinch_py/main.py
@@ -229,7 +229,6 @@ class OneInchSwap:
 
 
 class TransactionHelper:
-    # 1Inch gas oracle doesn't seem to exist any longer
     gas_oracle = "https://gas-price-api.1inch.io/v1.3/"
 
     chains = {
@@ -262,10 +261,14 @@ class TransactionHelper:
             response.raise_for_status()
             payload = response.json()
         except requests.exceptions.ConnectionError as e:
+            error_content = json.loads(e.response._content.decode("utf-8"))
             print("ConnectionError when doing a GET request from {}".format(url))
+            print(f"{error_content['error']} {error_content['description']}")
             payload = None
         except requests.exceptions.HTTPError:
+            error_content = json.loads(e.response._content.decode("utf-8"))
             print("HTTPError {}".format(url))
+            print(f"{error_content['error']} {error_content['description']}")
             payload = None
         return payload
 

--- a/oneinch_py/main.py
+++ b/oneinch_py/main.py
@@ -109,14 +109,12 @@ class OneInchSwap:
         """
         url = f'https://api.1inch.dev/token/v1.2/{self.chain_id}'
         result = self._get(url)
-        if not result.__contains__('tokens'):
-            return result
-        for key in result['tokens']:
-            token = result['tokens'][key]
+        for key in result:
+            token = result[key]
             self.tokens_by_address[key] = token
             self.tokens[token['symbol']] = token
         return self.tokens
-
+    
     def get_liquidity_sources(self):
         url = f'{self.base_url}/{self.version}/{self.chain_id}/liquidity-sources'
         result = self._get(url)

--- a/oneinch_py/main.py
+++ b/oneinch_py/main.py
@@ -11,11 +11,11 @@ class UnknownToken(Exception):
 
 
 class OneInchSwap:
-    base_url = 'https://api.1inch.io'
+    base_url = 'https://api.1inch.dev/swap'
+    api_key = ''
 
     version = {
-        "v4.0": "v4.0",
-        "v5.0": "v5.0"
+        "v5.2": "v5.2"
     }
 
     chains = {
@@ -29,30 +29,38 @@ class OneInchSwap:
         "fantom": "250"
     }
 
-    def __init__(self, address, chain='ethereum', version='v5.0'):
+    def __init__(self, api_key, address, chain='ethereum', version='v5.2'):
         self.presets = None
         self.tokens = {}
         self.tokens_by_address = {}
         self.protocols = []
         self.address = address
+        self.api_key = api_key
         self.version = version
         self.chain_id = self.chains[chain]
         self.chain = chain
         self.tokens = self.get_tokens()
         self.spender = self.get_spender()
 
-    @staticmethod
-    def _get(url, params=None, headers=None):
+   
+    def _get(self, url, params=None, headers=None):
         """ Implements a get request """
         try:
+            auth = ("Authorization", f"Bearer {self.api_key}")
+            if (headers == None):
+                headers = {"accept": "application/json", "Authorization": f"Bearer {self.api_key}"}
+            else:
+                headers["accept"] = "application/json"
+                headers["Authorization"] = f"Bearer {self.api_key}"
             response = requests.get(url, params=params, headers=headers)
             response.raise_for_status()
             payload = response.json()
         except requests.exceptions.ConnectionError as e:
             print("ConnectionError when doing a GET request from {}".format(url))
             payload = None
-        except requests.exceptions.HTTPError:
+        except requests.exceptions.HTTPError as e:
             print("HTTPError {}".format(url))
+            print(e.response)
             payload = None
         return payload
 

--- a/oneinch_py/main.py
+++ b/oneinch_py/main.py
@@ -58,12 +58,14 @@ class OneInchSwap:
             response.raise_for_status()
             payload = response.json()
         except requests.exceptions.ConnectionError as e:
+            error_content = json.loads(e.response._content.decode("utf-8"))
             print(f"ConnectionError with code {e.response.status_code} when doing a GET request from {format(url)}")
-            print(f"Full error content {e.response._content}")
+            print(f"{error_content['error']} {error_content['description']}")
             payload = None
         except requests.exceptions.HTTPError as e:
+            error_content = json.loads(e.response._content.decode("utf-8"))
             print(f"HTTPError with code {e.response.status_code} for a request {format(url)}")
-            print(f"Full error content {e.response._content}")
+            print(f"{error_content['error']} {error_content['description']}")
             payload = None
         return payload
 

--- a/oneinch_py/main.py
+++ b/oneinch_py/main.py
@@ -19,14 +19,17 @@ class OneInchSwap:
     }
 
     chains = {
-        "ethereum": '1',
-        "binance": '56',
+        "ethereum": "1",
+        "binance": "56",
         "polygon": "137",
         "optimism": "10",
         "arbitrum": "42161",
         "gnosis": "100",
         "avalanche": "43114",
-        "fantom": "250"
+        "fantom": "250",
+        "klaytn": "8217",
+        "aurora": "1313161554",
+        "zksync": "324"
     }
 
     def __init__(self, api_key, address, chain='ethereum', version='v5.2'):
@@ -228,8 +231,8 @@ class TransactionHelper:
     gas_oracle = "https://gas-price-api.1inch.io/v1.3/"
 
     chains = {
-        "ethereum": '1',
-        "binance": '56',
+        "ethereum": "1",
+        "binance": "56",
         "polygon": "137",
         "optimism": "10",
         "arbitrum": "42161",
@@ -349,14 +352,17 @@ class TransactionHelper:
 
 class OneInchOracle:
     chains = {
-        "ethereum": '1',
-        "binance": '56',
+        "ethereum": "1",
+        "binance": "56",
         "polygon": "137",
         "optimism": "10",
         "arbitrum": "42161",
         "gnosis": "100",
         "avalanche": "43114",
-        "fantom": "250"
+        "fantom": "250",
+        "klaytn": "8217",
+        "aurora": "1313161554",
+        "zksync": "324"
     }
 
     contracts = {

--- a/oneinch_py/main.py
+++ b/oneinch_py/main.py
@@ -46,7 +46,7 @@ class OneInchSwap:
     def _get(self, url, params=None, headers=None):
         """ Implements a get request """
         try:
-            if (headers == None):
+            if headers == None:
                 headers = {"accept": "application/json", "Authorization": f"Bearer {self.api_key}"}
             else:
                 headers["accept"] = "application/json"
@@ -224,6 +224,7 @@ class OneInchSwap:
 
 
 class TransactionHelper:
+    # 1Inch gas oracle doesn't seem to exist any longer
     gas_oracle = "https://gas-price-api.1inch.io/v1.3/"
 
     chains = {
@@ -243,10 +244,15 @@ class TransactionHelper:
     abi = json.loads(pkg_resources.read_text(__package__, 'erc20.json'))['result']
     abi_aggregator = json.loads(pkg_resources.read_text(__package__, 'aggregatorv5.json'))['result']
 
-    @staticmethod
-    def _get(url, params=None, headers=None):
+    def _get(self, url, params=None, headers=None):
         """ Implements a get request """
         try:
+            if headers == None:
+                headers = {"accept": "application/json", "Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"}
+            else:
+                headers["accept"] = "application/json"
+                headers["Authorization"] = f"Bearer {self.api_key}"
+                headers["Content-Type"] = "application/json"
             response = requests.get(url, params=params, headers=headers)
             response.raise_for_status()
             payload = response.json()
@@ -258,12 +264,13 @@ class TransactionHelper:
             payload = None
         return payload
 
-    def __init__(self, rpc_url, public_key, private_key, chain='ethereum', broadcast_1inch=False):
+    def __init__(self,  api_key, rpc_url, public_key, private_key, chain='ethereum', broadcast_1inch=False):
         self.w3 = Web3(Web3.HTTPProvider(rpc_url))
         if chain == 'polygon' or chain == 'avalanche':
             self.w3.middleware_onion.inject(geth_poa_middleware, layer=0)
         else:
             pass
+        self.api_key =  api_key
         self.public_key = public_key
         self.private_key = private_key
         self.chain = chain
@@ -272,6 +279,8 @@ class TransactionHelper:
 
     def build_tx(self, raw_tx, speed='high'):
         nonce = self.w3.eth.get_transaction_count(self.public_key)
+        if raw_tx == None:
+            return None
         if 'tx' in raw_tx:
             tx = raw_tx['tx']
         else:
@@ -286,7 +295,7 @@ class TransactionHelper:
         tx['value'] = int(tx['value'])
         tx['gas'] = int(tx['gas'] * 1.25)
         if self.chain == 'ethereum' or self.chain == 'polygon' or self.chain == 'avalanche' or self.chain == 'gnosis' or self.chain == 'klaytn':
-            gas = self._get(self.gas_oracle+self.chain_id)
+            gas = self._get(self.gas_oracle + self.chain_id)
             tx['maxPriorityFeePerGas'] = int(gas[speed]['maxPriorityFeePerGas'])
             tx['maxFeePerGas'] = int(gas[speed]['maxFeePerGas'])
             tx.pop('gasPrice')
@@ -299,10 +308,12 @@ class TransactionHelper:
         return signed_tx
 
     def broadcast_tx(self, signed_tx, timeout=360):
+        api_base_url = 'https://api.1inch.dev/tx-gateway/v1.1/'
+        api_headers = {"accept": "application/json", "Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"}
         if self.broadcast_1inch is True:
             tx_json = signed_tx.rawTransaction
             tx_json = {"rawTransaction": tx_json.hex()}
-            payload = requests.post('https://tx-gateway.1inch.io/v1.1/' + self.chain_id + '/broadcast', data=self.w3.toJSON(tx_json), headers={"accept": "application/json, text/plain, */*", "content-type": "application/json"})
+            payload = requests.post(api_base_url + self.chain_id + "/broadcast", data=self.w3.toJSON(tx_json), headers=api_headers)
             tx_hash = json.loads(payload.text)
             tx_hash = tx_hash['transactionHash']
             receipt = self.w3.eth.wait_for_transaction_receipt(tx_hash, timeout=timeout)

--- a/oneinch_py/main.py
+++ b/oneinch_py/main.py
@@ -46,7 +46,6 @@ class OneInchSwap:
     def _get(self, url, params=None, headers=None):
         """ Implements a get request """
         try:
-            auth = ("Authorization", f"Bearer {self.api_key}")
             if (headers == None):
                 headers = {"accept": "application/json", "Authorization": f"Bearer {self.api_key}"}
             else:
@@ -56,11 +55,12 @@ class OneInchSwap:
             response.raise_for_status()
             payload = response.json()
         except requests.exceptions.ConnectionError as e:
-            print("ConnectionError when doing a GET request from {}".format(url))
+            print(f"ConnectionError with code {e.response.status_code} when doing a GET request from {format(url)}")
+            print(f"Full error content {e.response._content}")
             payload = None
         except requests.exceptions.HTTPError as e:
-            print("HTTPError {}".format(url))
-            print(e.response)
+            print(f"HTTPError with code {e.response.status_code} for a request {format(url)}")
+            print(f"Full error content {e.response._content}")
             payload = None
         return payload
 

--- a/oneinch_py/main.py
+++ b/oneinch_py/main.py
@@ -69,7 +69,7 @@ class OneInchSwap:
 
     def _token_to_address(self, token: str):
         if len(token) == 42:
-            return self.w3.to_checksum_address(token)
+            return Web3.to_checksum_address(token)
         else:
             try:
                 address = self.tokens[token]['address']
@@ -243,7 +243,6 @@ class TransactionHelper:
         "aurora": "1313161554",
         "zksync": "324"
     }
-
 
     abi = json.loads(pkg_resources.read_text(__package__, 'erc20.json'))['result']
     abi_aggregator = json.loads(pkg_resources.read_text(__package__, 'aggregatorv5.json'))['result']


### PR DESCRIPTION
The get_token method was switched from Swap to Token API. Swap API wraps the response in "tokens", but the Token API doesn't. As a result, the self.tokens was not a dict of the raw API response, so the token address was the key, not the symbol. This caused other pieces of the code to fail.

The proposed solution updates the get_tokens method to more accurately read the response from the API, generating the same dict in self.tokens as before. 

The solution was tested locally against Python 3.8. 