### PR TITLE
Update API call in get_swap(), fixes #26

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ oracle = OneInchOracle(rpc_url, chain='ethereum')
 helper.chains
 # {"ethereum": "1", "binance": "56", "polygon": "137", "avalanche": "43114"}
 
+# To get gas prices
+helper.get_gas_prices()
+
 # Straight to business:
 # Get a swap and do the swap
 result = exchange.get_swap("USDT", "ETH", 10, 0.5) # get the swap transaction

--- a/oneinch_py/main.py
+++ b/oneinch_py/main.py
@@ -152,13 +152,13 @@ class OneInchSwap:
         else:
             amount_in_wei = int(amount * 10 ** decimal)
         url = f'{self.base_url}/{self.version}/{self.chain_id}/quote'
-        url = url + f'?fromTokenAddress={from_address}&toTokenAddress={to_address}&amount={amount_in_wei}'
+        url = url + f'?src={from_address}&dst={to_address}&amount={amount_in_wei}'
         if kwargs is not None:
             result = self._get(url, params=kwargs)
         else:
             result = self._get(url)
-        from_base = Decimal(result['fromTokenAmount']) / Decimal(10 ** result['fromToken']['decimals'])
-        to_base = Decimal(result['toTokenAmount']) / Decimal(10 ** result['toToken']['decimals'])
+        from_base = amount_in_wei
+        to_base = int(result['toAmount'])
         if from_base > to_base:
             rate = from_base / to_base
         else:

--- a/oneinch_py/main.py
+++ b/oneinch_py/main.py
@@ -299,13 +299,16 @@ class TransactionHelper:
         tx['value'] = int(tx['value'])
         tx['gas'] = int(tx['gas'] * 1.25)
         if self.chain == 'ethereum' or self.chain == 'polygon' or self.chain == 'avalanche' or self.chain == 'gnosis' or self.chain == 'klaytn':
-            gas = self._get(self.gas_oracle + self.chain_id)
+            gas = self.get_gas_prices()
             tx['maxPriorityFeePerGas'] = int(gas[speed]['maxPriorityFeePerGas'])
             tx['maxFeePerGas'] = int(gas[speed]['maxFeePerGas'])
             tx.pop('gasPrice')
         else:
             tx['gasPrice'] = int(tx['gasPrice'])
         return tx
+    
+    def get_gas_prices(self):
+        return self._get(self.gas_oracle + self.chain_id)
 
     def sign_tx(self, tx):
         if tx == None:

--- a/oneinch_py/main.py
+++ b/oneinch_py/main.py
@@ -381,7 +381,8 @@ class OneInchOracle:
         "arbitrum": "0x735247fb0a604c0adC6cab38ACE16D0DbA31295F",
         "gnosis": "0x142DB045195CEcaBe415161e1dF1CF0337A4d02E",
         "avalanche": "0xBd0c7AaF0bF082712EbE919a9dD94b2d978f79A9",
-        "fantom": "0xE8E598A1041b6fDB13999D275a202847D9b654ca"
+        "fantom": "0xE8E598A1041b6fDB13999D275a202847D9b654ca",
+        "zksync": "0xC762d56614D3411eC6fABD56cb075D904b801613"
     }
 
     # multicall_address = "0xDA3C19c6Fe954576707fA24695Efb830D9ccA1CA"

--- a/oneinch_py/main.py
+++ b/oneinch_py/main.py
@@ -116,8 +116,6 @@ class OneInchSwap:
     def get_liquidity_sources(self):
         url = f'{self.base_url}/{self.version}/{self.chain_id}/liquidity-sources'
         result = self._get(url)
-        if not result.__contains__('liquidity-sources'):
-            return result
         self.protocols = result
         return self.protocols
 

--- a/oneinch_py/main.py
+++ b/oneinch_py/main.py
@@ -109,14 +109,12 @@ class OneInchSwap:
         """
         url = f'https://api.1inch.dev/token/v1.2/{self.chain_id}'
         result = self._get(url)
-        if not result.__contains__('tokens'):
-            return result
-        for key in result['tokens']:
-            token = result['tokens'][key]
+        for key in result:
+            token = result[key]
             self.tokens_by_address[key] = token
             self.tokens[token['symbol']] = token
         return self.tokens
-
+    
     def get_liquidity_sources(self):
         url = f'{self.base_url}/{self.version}/{self.chain_id}/liquidity-sources'
         result = self._get(url)

--- a/oneinch_py/main.py
+++ b/oneinch_py/main.py
@@ -95,8 +95,6 @@ class OneInchSwap:
     def get_spender(self):
         url = f'{self.base_url}/{self.version}/{self.chain_id}/approve/spender'
         result = self._get(url)
-        if not result.__contains__('spender'):
-            return result
         self.spender = result
         return self.spender
 

--- a/oneinch_py/main.py
+++ b/oneinch_py/main.py
@@ -122,8 +122,6 @@ class OneInchSwap:
     def get_presets(self):
         url = f'{self.base_url}/{self.version}/{self.chain_id}/presets'
         result = self._get(url)
-        if not result.__contains__('presets'):
-            return result
         self.presets = result
         return self.presets
 

--- a/oneinch_py/main.py
+++ b/oneinch_py/main.py
@@ -183,8 +183,8 @@ class OneInchSwap:
         else:
             amount_in_wei = int(amount * 10 ** decimal)
         url = f'{self.base_url}/{self.version}/{self.chain_id}/swap'
-        url = url + f'?fromTokenAddress={from_address}&toTokenAddress={to_address}&amount={amount_in_wei}'
-        url = url + f'&fromAddress={send_address}&slippage={slippage}'
+        url = url + f'?src={from_address}&dst={to_address}&amount={amount_in_wei}'
+        url = url + f'&from={send_address}&slippage={slippage}'
         if kwargs is not None:
             result = self._get(url, params=kwargs)
         else:


### PR DESCRIPTION
It seems like parameter updates in get_swap() fell through the cracks. My apologies. Adding that fix now, the API parameters are now `src` & `dst` and `from` to match the API.

I also put the code for fetching gas prices into a separate method, in cases where gas prices may need to be fetched outside the transaction. This was also added to the README.